### PR TITLE
Revert "contributing guide"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing to babern
-
-


### PR DESCRIPTION
### Reverts Ardustri/babern#2
because there is no guide in it